### PR TITLE
發現兩個重複且名稱一樣的icon

### DIFF
--- a/src/partials/elements/_icon.sass
+++ b/src/partials/elements/_icon.sass
@@ -337,10 +337,6 @@ i.icon.privacy:before
     content: "\f084"
 i.icon.settings:before
     content: "\f085"
-i.icon.comments:before
-    content: "\f086"
-i.icon.external:before
-    content: "\f08e"
 i.icon.trophy:before
     content: "\f091"
 i.icon.payment:before


### PR DESCRIPTION
在網站的document裡發現了以下兩個重複icon

- comments
- external

<img width="778" alt="default" src="https://user-images.githubusercontent.com/6300506/34850682-dfc17b00-f761-11e7-97cd-d0751ed37ac6.png">
