### PR TITLE
feat: add justify alignment option to text utility classes

### DIFF
--- a/src/text.css
+++ b/src/text.css
@@ -256,6 +256,9 @@
 .ts-text.is-end-aligned {
     text-align: right;
 }
+.ts-text.is-justify-aligned {
+    text-align: justify;
+}
 
 /**
  * Label


### PR DESCRIPTION
## 中文
當撰寫中文時，經常會發現左右無法對齊的問題，這會導致出現奇怪的空格，對於那些有強迫症的人來說可能會造成不適。為了解決這個問題，我想在 TocasUI 中新增左右對齊的 CSS，我新增了 ".ts-text.is-justify-aligned" CSS 類別，可以將文字對齊方式設置為左右對齊。希望這個新增功能可以解決這個問題。  

## 英文
When writing in Chinese, it is often difficult to properly align text, which can result in strange spacing issues. To avoid frustrating those with OCD, I would like to add a left and right alignment CSS class to TocasUI. I have introduced a new CSS class, ".ts-text.is-justify-aligned", which aligns the text to both the left and right. I hope this new feature will solve the problem.